### PR TITLE
fix_error_computing_in _the_training_example

### DIFF
--- a/main_char_train.py
+++ b/main_char_train.py
@@ -44,7 +44,7 @@ for i in xrange(200):
         error += cost
     in_time = time.time() - in_start
 
-    error /= len(seqs);
+    error /= len(data_xy);
     if error < g_error:
         g_error = error
         #save_model("./model/rnn.model_" + str(i), model)


### PR DESCRIPTION
in the example, the accumulated error for batches should divide batch size, not training data size, have also tested in keras